### PR TITLE
[修复] nopoll 依赖的 tinycrypt 软件包更新导致的编译错误

### DIFF
--- a/nopoll/nopoll_conn.c
+++ b/nopoll/nopoll_conn.c
@@ -2502,7 +2502,7 @@ char * nopoll_conn_produce_accept_key (noPollCtx * ctx, const char * websocket_k
 #if NOPOLL_OS_RTTHREAD
 #define SHA_BUF_SZ	20
 	unsigned char   buffer[SHA_BUF_SZ];
-	sha1_context sha1_ctx;
+	tiny_sha1_context sha1_ctx;
 	unsigned int    md_len = SHA_BUF_SZ;
 
 	if (websocket_key == NULL)
@@ -2519,9 +2519,9 @@ char * nopoll_conn_produce_accept_key (noPollCtx * ctx, const char * websocket_k
 	nopoll_log (ctx, NOPOLL_LEVEL_DEBUG, "base key value: %s", accept_key);
 
 	/* now sha-1 */
-    sha1_starts( &sha1_ctx );
-    sha1_update( &sha1_ctx, accept_key, strlen (accept_key) );
-    sha1_finish( &sha1_ctx, buffer );
+    tiny_sha1_starts( &sha1_ctx );
+    tiny_sha1_update( &sha1_ctx, accept_key, strlen (accept_key) );
+    tiny_sha1_finish( &sha1_ctx, buffer );
 
 	nopoll_log (ctx, NOPOLL_LEVEL_DEBUG, "Sha-1 length is: %u", md_len);
 	/* now convert into base64 */

--- a/nopoll/nopoll_rtthread.h
+++ b/nopoll/nopoll_rtthread.h
@@ -2,7 +2,7 @@
 #define NOPOLL_RTTHREAD_H__
 
 #include "nopoll.h"
-#include <sha1.h>
+#include <tiny_sha1.h>
 
 unsigned int nopoll_rtt_random(void);
 


### PR DESCRIPTION
[修复] nopoll 依赖的 tinycrypt 软件包更新导致的编译错误

Signed-off-by: MurphyZhao <d2014zjt@163.com>