### PR TITLE
修改服务器模式时监听端口不正确以及关闭socket无法释放资源的BUG

### DIFF
--- a/nopoll/nopoll_conn.c
+++ b/nopoll/nopoll_conn.c
@@ -1881,7 +1881,6 @@ void          nopoll_conn_shutdown (noPollConn * conn)
 
 	/* shutdown connection here */
 	if (conn->session != NOPOLL_INVALID_SOCKET) {
-	        shutdown (conn->session, SHUT_RDWR);
 		nopoll_close_socket (conn->session);
 	}
 	conn->session = NOPOLL_INVALID_SOCKET;

--- a/nopoll/nopoll_decl.h
+++ b/nopoll/nopoll_decl.h
@@ -178,7 +178,7 @@
 #define NOPOLL_SOCKET          int
 #define NOPOLL_INVALID_SOCKET  -1
 #define NOPOLL_SOCKET_ERROR    -1
-#define nopoll_close_socket(s) do {if ( s >= 0) {lwip_close (s);}} while (0)
+#define nopoll_close_socket(s) do {if ( s >= 0) {closesocket (s);}} while (0)
 
 #endif /* end defined(AXL_OS_UNIX) */
 

--- a/nopoll/nopoll_listener.c
+++ b/nopoll/nopoll_listener.c
@@ -109,6 +109,9 @@ NOPOLL_SOCKET     __nopoll_listener_sock_listen_internal      (noPollCtx        
 #endif
 	} /* end switch */
 
+	/* get integer port */
+	int_port  = (uint16_t) atoi (port);
+	
 	memset(&saddr, 0, sizeof(struct sockaddr_in));
 	saddr.sin_family          = AF_INET;
 	saddr.sin_port            = htons(int_port);
@@ -134,8 +137,6 @@ NOPOLL_SOCKET     __nopoll_listener_sock_listen_internal      (noPollCtx        
 	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &unit, sizeof (unit));
 #endif 
 
-	/* get integer port */
-	int_port  = (uint16_t) atoi (port);
 
 	/* call to bind */
 	tries    = 0;


### PR DESCRIPTION
修复了nopoll作为服务器使用时的一些BUG。

【修复】原版监听端口的类型转换在赋值以后才调用，会出现实际端口不正确的问题。
【修复】原版在关闭socket时使用了shutdown而非closesocket，导致资源没有被释放，当多次建立连接时会连接失败。